### PR TITLE
Pad numbers of result matrix with zeros

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <time.h>
+#include <iomanip>
 
 // Number of vertices in the graph
 #define V 10
@@ -88,7 +89,7 @@ void printSolutionFloyd(int dist[][V])
             if (dist[i][j] == INF)
                 cout<<"INF"<<"     ";
             else
-                cout<<dist[i][j]<<"     ";
+                cout << setfill('0') << setw(3) << dist[i][j] << "     ";
         }
         cout<<endl;
     }
@@ -177,6 +178,6 @@ int main()
     t = clock() - t;
     time_taken = ((double) t) / CLOCKS_PER_SEC;
     cout << "Time taken in Warshall: " << time_taken << endl;
-    
+
     return 0;
 }


### PR DESCRIPTION
Numbers were misaligned because some of them had 1 digit and some 2 or more.

Before:

```
The following matrix shows the shortest distances between every pair of vertices
0     7     1     3     2     2     7     1     0     5
5     0     1     2     2     2     4     6     4     6
4     6     0     7     1     1     6     5     3     9
4     11     5     0     5     4     10     5     4     4
3     8     2     6     3     0     6     4     3     8
3     8     2     6     3     0     6     4     3     8
4     5     3     7     1     1     0     5     4     6
1     6     0     4     1     1     6     0     1     6
2     9     3     5     4     3     9     3     0     7
0     7     1     3     2     2     7     1     0     0
```

Now:

```
The following matrix shows the shortest distances between every pair of vertices
000     007     001     003     002     002     007     001     000     005
005     000     001     002     002     002     004     006     004     006
004     006     000     007     001     001     006     005     003     009
004     011     005     000     005     004     010     005     004     004
003     008     002     006     003     000     006     004     003     008
003     008     002     006     003     000     006     004     003     008
004     005     003     007     001     001     000     005     004     006
001     006     000     004     001     001     006     000     001     006
002     009     003     005     004     003     009     003     000     007
000     007     001     003     002     002     007     001     000     000
```